### PR TITLE
Toggle location

### DIFF
--- a/screens/CenterBtn.js
+++ b/screens/CenterBtn.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { specificStyles } from "../styles";
+
+//Button to center user on map. Useful if they toggle their location back and forth, as map does not automatically re-center
+const CenterBtn = ({ locationAccess, setMapRegion }) => {
+  const buttonAction =
+    locationAccess === "granted"
+      ? () => setMapRegion("mapRegion")
+      : () =>
+          alert("Turn on location services to center map on your location.");
+  return (
+    <View>
+      <Text style={specificStyles.centerBtn} onPress={buttonAction}>
+        C
+      </Text>
+    </View>
+  );
+};
+
+export default CenterBtn

--- a/screens/Map.js
+++ b/screens/Map.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { MapView, Location, Permissions } from "expo";
+import { AppState } from "react-native";
 import MenuBtn from "./MenuBtn";
+import CenterBtn from "./CenterBtn";
 import { database } from "../db.js";
 import layout from "../constants/Layout";
 
@@ -15,8 +17,9 @@ export default class Map extends React.Component {
         latitudeDelta: 0.0922,
         longitudeDelta: 0.0421
       },
-      locationResult: "",
-      initialRegion: null
+      locationResult: "denied",
+      initialRegion: null,
+      appState: AppState.currentState
     };
     this.db = database.ref();
   }
@@ -27,7 +30,31 @@ export default class Map extends React.Component {
 
   componentDidMount = async () => {
     this._listenForUpdatesToDatabase(this.db);
+    AppState.addEventListener("change", this._handleAppStateChange);
     await this._getLocationAsync();
+  };
+
+  componentWillUnmount() {
+    AppState.removeEventListener("change", this._handleAppStateChange);
+  }
+
+  _handleAppStateChange = async nextAppState => {
+    if (
+      this.state.appState.match(/inactive|background/) &&
+      nextAppState === "active"
+    ) {
+      console.log("App has come to the foreground!");
+      let { permissions, status } = await Permissions.getAsync(Permissions.LOCATION);
+      const locationOn = permissions.location.ios.scope === 'whenInUse'
+
+      if(status === 'denied' && locationOn) {
+        //This condition is to protect against the case where a user initially denies access or opens the app with denied access from a previous session (i.e. Permission status for location will never flip from 'denied'). If both conditions are met, it prompts the user to re-allow access to their location.
+        const refresh = await Permissions.askAsync(Permissions.LOCATION);
+        status = refresh.status
+       }
+      this.setState({ locationResult: status});
+    }
+    this.setState({ appState: nextAppState });
   };
 
   _listenForUpdatesToDatabase = db => {
@@ -43,16 +70,18 @@ export default class Map extends React.Component {
 
   _getLocationAsync = async () => {
     let { status } = await Permissions.askAsync(Permissions.LOCATION);
-    if (status !== "granted") {
-      this.setState({
-        locationResult: "Permission to access location was denied"
-      });
+    if (status === "granted") {
+      this._setMapRegionAsync("initialRegion");
     }
+    this.setState({ locationResult: status });
+  };
 
+  //Sets the map region to user's location. Used for both initializing the map and the "center" button.
+  _setMapRegionAsync = async regionType => {
     let location = await Location.getCurrentPositionAsync({});
 
     this.setState({
-      initialRegion: {
+      [regionType]: {
         latitude: location.coords.latitude,
         longitude: location.coords.longitude,
         longitudeDelta: 0.005,
@@ -81,6 +110,7 @@ export default class Map extends React.Component {
         region={this.state.mapRegion}
       >
         <MenuBtn setScreen={this.props.setScreen} />
+        <CenterBtn locationAccess={this.state.locationResult} setMapRegion={this._setMapRegionAsync}/>
         {this.state.markers.map(marker => (
           <MapView.Marker
             key={marker.name}

--- a/screens/Menu.js
+++ b/screens/Menu.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Linking } from "react-native";
 import { specificStyles } from "../styles";
 import screenNames from "../constants/ScreenNames";
 
@@ -8,13 +8,27 @@ export default class Menu extends React.Component {
     super(props);
   }
 
+  changeLocationSettings = async () => {
+    //Opens up settings so user can toggle their location on or off
+      const supported = await Linking.canOpenURL("app-settings:")
+        if (!supported) {
+            alert("Cannot open app settings - please open settings manually to toggle location.");
+          } else {
+            Linking.openURL("app-settings:");
+          }
+    //closes the menu before going to Settings
+      this.props.toggleShowMenu();
+  };
+
   render() {
     return (
       <View>
         {this.props.visible && (
           <View style={specificStyles.menuContainer}>
             <View style={specificStyles.menu}>
-              <Text>Toggle Location Settings</Text>
+              <Text onPress={this.changeLocationSettings}>
+                Toggle Location Settings
+              </Text>
               <Text onPress={() => this.props.setScreen(screenNames.list)}>
                 Go To My List
               </Text>

--- a/styles.js
+++ b/styles.js
@@ -34,5 +34,10 @@ export const specificStyles = StyleSheet.create({
     flexDirection: "column",
     justifyContent: "space-around",
     alignItems: "center"
+  },
+  centerBtn: {
+    top: 500,
+    marginLeft: 315,
+    fontSize: 40
   }
 });


### PR DESCRIPTION
* Users can toggle their location from the app by selecting the option from the menu. This will automatically bring them to the settings for the app and they can toggle location preferences. 
* Set up listener in Map to check if the map comes back into the foreground, as this may indicate that the location preferences were toggled.
* Also added a button to the map "C" that will re-center the user on the map if their location preferences are turned on, or prompt them to turn on their location preferences if they want to use the button. 
* I left some documenting comments in Map.js and CenterBtn.js
* Also moved the logic that sets the area of the map into it's own method so it can be used by both CenterBtn and _getLocationAsync