### PR TITLE
Moves My List To Bottom Drawer And Out of Menu

### DIFF
--- a/screens/Drawer.js
+++ b/screens/Drawer.js
@@ -1,6 +1,5 @@
 import React from "react";
 import BottomDrawer from "rn-bottom-drawer";
-import Landmark from "./Landmark";
 import layout from "../constants/Layout";
 import ExploreBrooklyn from "./ExploreBrooklyn";
 
@@ -8,11 +7,12 @@ const screenHeight = layout.window.height;
 
 export default class Drawer extends React.Component {
   renderContent = () => {
-    if (this.props.selectedLandmark.name) {
-      return <Landmark landmarkDetails={this.props.selectedLandmark} />;
-    } else {
-      return <ExploreBrooklyn landmarks={this.props.landmarks} />;
-    }
+    return (
+      <ExploreBrooklyn
+        landmarks={this.props.landmarks}
+        landmarkDetails={this.props.selectedLandmark}
+      />
+    );
   };
 
   render() {

--- a/screens/ExploreBrooklyn.js
+++ b/screens/ExploreBrooklyn.js
@@ -1,35 +1,44 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
+import NearMe from "./NearMe";
+import List from "./List";
 
 export default class ExploreBrooklyn extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showSavedList: false
+    };
+  }
+
+  showSavedListView = () => {
+    this.setState({ showSavedList: true });
+  };
+
+  showNearMeView = () => {
+    this.setState({ showSavedList: false });
+  };
+
   render() {
-    const landmarks = this.props.landmarks;
-    if (landmarks.length) {
-      return (
-        <View style={reusableStyles.block}>
-          <Text style={{ ...reusableStyles.header1, textAlign: "center" }}>
-            ExploreBrooklyn
-          </Text>
-          <View>
-            {landmarks.map(landmark => (
-              <View key={landmark.name} style={specificStyles.listItemWithIcon}>
-                <View style={reusableStyles.listIcon} />
-                <View>
-                  <Text style={reusableStyles.header2}>{landmark.name}</Text>
-                  <Text style={reusableStyles.text1}>{landmark.location}</Text>
-                </View>
-              </View>
-            ))}
-          </View>
+    return (
+      <View style={reusableStyles.block}>
+        <View style={reusableStyles.flexrow}>
+          <TouchableOpacity onPress={this.showNearMeView}>
+            <Text style={reusableStyles.header1}>Near Me</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={this.showSavedListView}>
+            <Text style={reusableStyles.header1}>Saved</Text>
+          </TouchableOpacity>
         </View>
-      );
-    } else {
-      return (
         <View>
-          <Text>Explore Brooklyn</Text>
+          {this.state.showSavedList ? (
+            <List />
+          ) : (
+            <NearMe landmarks={this.props.landmarks} />
+          )}
         </View>
-      );
-    }
+      </View>
+    );
   }
 }

--- a/screens/ExploreBrooklyn.js
+++ b/screens/ExploreBrooklyn.js
@@ -3,41 +3,63 @@ import { View, Text, TouchableOpacity } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
 import NearMe from "./NearMe";
 import List from "./List";
+import Landmark from "./Landmark";
 
 export default class ExploreBrooklyn extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      showSavedList: false
+      showSavedList: false,
+      showNearMe: true
     };
   }
 
   showSavedListView = () => {
-    this.setState({ showSavedList: true });
+    this.setState({
+      showNearMe: false,
+      showSavedList: true
+    });
   };
 
   showNearMeView = () => {
-    this.setState({ showSavedList: false });
+    this.setState({
+      showNearMe: true,
+      showSavedList: false
+    });
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.landmarkDetails !== this.props.landmarkDetails) {
+      this.setState({
+        showNearMe: false,
+        showSavedList: false
+      });
+    }
+  }
+
   render() {
+    const { showNearMe, showSavedList } = this.state;
+    const showLandmarkDetails =
+      this.props.landmarkDetails.name && !showNearMe && !showSavedList;
+
     return (
       <View style={reusableStyles.block}>
         <View style={reusableStyles.flexrow}>
           <TouchableOpacity onPress={this.showNearMeView}>
-            <Text style={reusableStyles.header1}>Near Me</Text>
+            <Text style={specificStyles.drawerButtons}>Near Me</Text>
           </TouchableOpacity>
           <TouchableOpacity onPress={this.showSavedListView}>
-            <Text style={reusableStyles.header1}>Saved</Text>
+            <Text style={specificStyles.drawerButtons}>Saved</Text>
           </TouchableOpacity>
         </View>
-        <View>
-          {this.state.showSavedList ? (
-            <List />
-          ) : (
-            <NearMe landmarks={this.props.landmarks} />
-          )}
-        </View>
+
+        {showLandmarkDetails && (
+          <Landmark landmarkDetails={this.props.landmarkDetails} />
+        )}
+
+        {this.state.showSavedList && <List />}
+
+        {this.state.showNearMe && <NearMe landmarks={this.props.landmarks} />}
       </View>
     );
   }

--- a/screens/List.js
+++ b/screens/List.js
@@ -46,21 +46,16 @@ export default class List extends React.Component {
     const { savedLandmarks } = this.state;
 
     const landmarksList = (
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <Text
-          style={{ fontSize: 30, fontWeight: "bold" }}
-          onPress={() => this.props.setScreen(screenNames.home)}
-        >
-          X
-        </Text>
-        <Text>My Saved Landmarks:</Text>
+      <View>
         {savedLandmarks &&
-          savedLandmarks.map((landmark, i) => {
+          savedLandmarks.map(landmark => {
             return (
-              <View style={specificStyles.listItemWithIcon}>
-                <Text key={landmark.name} style={reusableStyles.header2}>
-                  Landmark {i + 1}: {landmark.name}
-                </Text>
+              <View key={landmark.name} style={specificStyles.listItemWithIcon}>
+                <View style={reusableStyles.listIcon} />
+                <View>
+                  <Text style={reusableStyles.header2}>{landmark.name}</Text>
+                  <Text style={reusableStyles.text1}>{landmark.location}</Text>
+                </View>
                 <Button
                   title="delete"
                   onPress={() => this.deleteLandmark(landmark.name)}
@@ -73,13 +68,7 @@ export default class List extends React.Component {
     );
 
     const noLandmarks = (
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <Text
-          style={{ fontSize: 30, fontWeight: "bold" }}
-          onPress={() => this.props.setScreen(screenNames.home)}
-        >
-          X
-        </Text>
+      <View>
         <Text>You haven't saved anything yet!</Text>
       </View>
     );

--- a/screens/Map.js
+++ b/screens/Map.js
@@ -98,7 +98,6 @@ export default class Map extends React.Component {
         zoomEnabled={true}
         initialRegion={this.state.initialRegion}
       >
-        {/* @TODO: refactor menu so list screen doesn't unmount the map and therefore reset initialRegion */}
         <MenuBtn setScreen={this.props.setScreen} />
         {/* @TODO: refactor C Button because it doesn't recenter on user's location anymore. Possibly use built in showsMyLocationButton */}
         <CenterBtn

--- a/screens/Menu.js
+++ b/screens/Menu.js
@@ -10,14 +10,16 @@ export default class Menu extends React.Component {
 
   changeLocationSettings = async () => {
     //Opens up settings so user can toggle their location on or off
-      const supported = await Linking.canOpenURL("app-settings:")
-        if (!supported) {
-            alert("Cannot open app settings - please open settings manually to toggle location.");
-          } else {
-            Linking.openURL("app-settings:");
-          }
+    const supported = await Linking.canOpenURL("app-settings:");
+    if (!supported) {
+      alert(
+        "Cannot open app settings - please open settings manually to toggle location."
+      );
+    } else {
+      Linking.openURL("app-settings:");
+    }
     //closes the menu before going to Settings
-      this.props.toggleShowMenu();
+    this.props.toggleShowMenu();
   };
 
   render() {
@@ -28,9 +30,6 @@ export default class Menu extends React.Component {
             <View style={specificStyles.menu}>
               <Text onPress={this.changeLocationSettings}>
                 Toggle Location Settings
-              </Text>
-              <Text onPress={() => this.props.setScreen(screenNames.list)}>
-                Go To My List
               </Text>
             </View>
           </View>

--- a/screens/MenuBtn.js
+++ b/screens/MenuBtn.js
@@ -18,13 +18,8 @@ export default class MenuBtn extends React.Component {
   render() {
     return (
       <View>
-        <Text
-          style={specificStyles.menuBtn}
-          onPress={() => {
-            this.toggleShowMenu();
-          }}
-        >
-        X
+        <Text style={specificStyles.menuBtn} onPress={this.toggleShowMenu}>
+          X
         </Text>
         <Menu
           visible={this.state.showMenu}

--- a/screens/NearMe.js
+++ b/screens/NearMe.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { reusableStyles, specificStyles } from "../styles";
+
+export default class NearMe extends React.Component {
+  render() {
+    const landmarks = this.props.landmarks;
+    if (landmarks.length) {
+      return (
+        <View>
+          {landmarks.map(landmark => (
+            <View key={landmark.name} style={specificStyles.listItemWithIcon}>
+              <View style={reusableStyles.listIcon} />
+              <View>
+                <Text style={reusableStyles.header2}>{landmark.name}</Text>
+                <Text style={reusableStyles.text1}>{landmark.location}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      );
+    } else {
+      return (
+        <View>
+          <Text>Fetching landmarks</Text>
+        </View>
+      );
+    }
+  }
+}

--- a/styles.js
+++ b/styles.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from "react-native";
+import { stopLocationUpdatesAsync } from "expo-location";
 
 export const reusableStyles = StyleSheet.create({
   listIcon: {
@@ -87,5 +88,13 @@ export const specificStyles = StyleSheet.create({
   listItemWithIcon: {
     flexDirection: "row",
     marginBottom: 5
+  },
+  drawerButtons: {
+    fontFamily: "nunito-bold",
+    fontSize: 16,
+    borderWidth: 1,
+    borderColor: "black",
+    borderRadius: 6,
+    padding: 5
   }
 });

--- a/styles.js
+++ b/styles.js
@@ -1,5 +1,4 @@
 import { StyleSheet } from "react-native";
-import { stopLocationUpdatesAsync } from "expo-location";
 
 export const reusableStyles = StyleSheet.create({
   listIcon: {


### PR DESCRIPTION
- [x] Removes 'Go to My List' from the menu
- [x] Adds a view to see landmark details in the bottom drawer

(Note: I added in that `ComponentDidUpdate` because the drawer only mounts once and once we have a `selectedLandmark` on state, that doesn't get cleared until you select another landmark. So without that `ComponentDidUpdate`, it throws off the logic of when to show the other views. It was either getting stuck on the landmark details and clicking on nearby or saved wouldn't do anything or it wouldn't show new landmarks because either nearby or saved was true. This way, we effectively clear the state every time we select a new landmark.

But that also means that if you click on a landmark and view the details, then switch to 'near me' or 'saved,' and then try to click on the same landmark again that you won't be able to see the details again. Because `ComponentDidUpdate` won't fire.)