### PR TITLE
show landmark details when tap landmark in list

### DIFF
--- a/screens/ExploreBrooklyn.js
+++ b/screens/ExploreBrooklyn.js
@@ -60,14 +60,13 @@ class ExploreBrooklyn extends React.Component {
 
         {this.state.showSavedList && <List />}
 
-        {this.state.showNearMe && <NearMe landmarks={this.props.landmarks} />}
+        {this.state.showNearMe && <NearMe />}
       </View>
     );
   }
 }
 
 const mapStateToProps = state => ({
-  landmarks: state.landmarks.data || [],
   landmarkDetails: state.selectedLandmark || {}
 });
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { connect } from 'react-redux'
+import { connect } from "react-redux";
 import { View, Text, TouchableOpacity } from "react-native";
 import Map from "./Map";
 import Drawer from "./Drawer";
 import { specificStyles } from "../styles";
 import { database } from "../db.js";
-import {fetchLandmarks} from '../store/landmarks'
+import { fetchLandmarks } from "../store/landmarks";
 
 class HomeScreen extends React.Component {
   constructor(props) {
@@ -20,39 +20,38 @@ class HomeScreen extends React.Component {
   }
 
   componentDidMount = async () => {
-    await this.props.getLandmarks(this.db)
+    await this.props.getLandmarks(this.db);
   };
 
   render() {
-    return (
-    !this.props.err ?
-    <View style={specificStyles.main}>
-      <View>
-          <Map
-            markers={this.props.landmarks}
-          />
-          <Drawer
-            landmarks={this.props.landmarks}
-          />
+    return !this.props.err ? (
+      <View style={specificStyles.main}>
+        <View>
+          <Map />
+          <Drawer />
         </View>
-    </View> :
-    <View style={specificStyles.main}>
-    <Text>There was a problem loading the landmarks.</Text>
-    <TouchableOpacity onClick={() => this.props.getLandmarks(this.db)}><Text>Retry</Text></TouchableOpacity>
-  </View>
-
-    )
+      </View>
+    ) : (
+      <View style={specificStyles.main}>
+        <Text>There was a problem loading the landmarks.</Text>
+        <TouchableOpacity onClick={() => this.props.getLandmarks(this.db)}>
+          <Text>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
   }
 }
-
 
 const mapStateToProps = state => ({
   landmarks: state.landmarks.data || [],
   err: state.landmarks.err
-})
+});
 
 const mapDispatchToProps = dispatch => ({
-  getLandmarks: (db) => dispatch(fetchLandmarks(db))
-})
+  getLandmarks: db => dispatch(fetchLandmarks(db))
+});
 
-export default connect(mapStateToProps, mapDispatchToProps)(HomeScreen)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(HomeScreen);

--- a/screens/List.js
+++ b/screens/List.js
@@ -1,8 +1,10 @@
 import React from "react";
+import { connect } from "react-redux";
 import { View, Text, AsyncStorage, TouchableOpacity } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
+import { setLandmark } from "../store/selectedLandmark";
 
-export default class List extends React.Component {
+class List extends React.Component {
   constructor() {
     super();
     this.state = {
@@ -55,17 +57,21 @@ export default class List extends React.Component {
                   style={specificStyles.listItemWithIcon}
                 >
                   <View style={reusableStyles.listIcon} />
-                  <View style={reusableStyles.block}>
+                  <TouchableOpacity
+                    style={reusableStyles.block}
+                    onPress={() => this.props.selectLandmark(landmark)}
+                  >
                     <Text style={reusableStyles.header2}>{landmark.name}</Text>
                     <Text style={reusableStyles.text1}>
                       {landmark.location}
                     </Text>
-                    <TouchableOpacity
-                      onPress={() => this.deleteLandmark(landmark.name)}
-                    >
-                      <Text style={specificStyles.listButtons}>Delete</Text>
-                    </TouchableOpacity>
-                  </View>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() => this.deleteLandmark(landmark.name)}
+                    style={reusableStyles.button}
+                  >
+                    <Text style={reusableStyles.header2}>X</Text>
+                  </TouchableOpacity>
                 </View>
               </View>
             );
@@ -90,3 +96,14 @@ export default class List extends React.Component {
     return haveLandmarks ? landmarksList : noLandmarks;
   }
 }
+
+const mapStateToProps = () => ({});
+
+const mapDispatchToProps = dispatch => ({
+  selectLandmark: landmark => dispatch(setLandmark(landmark))
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(List);

--- a/screens/Map.js
+++ b/screens/Map.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { connect } from "react-redux"
+import { connect } from "react-redux";
 import MapView, { PROVIDER_GOOGLE, Marker, Polyline } from "react-native-maps";
 import {
   AppState,
@@ -12,7 +12,7 @@ import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import MenuBtn from "./MenuBtn";
 import { specificStyles } from "../styles";
-import { setLandmark } from '../store/selectedLandmark'
+import { setLandmark } from "../store/selectedLandmark";
 
 const MapMarkers = ({ markers, setRegionAndSelectLandmark }) => {
   if (markers)
@@ -130,10 +130,10 @@ class Map extends React.Component {
           initialRegion={this.state.initialRegion}
           region={this.state.region}
         >
-            <MapMarkers
-              markers={this.props.markers || []}
-              setRegionAndSelectLandmark={this.setRegionAndSelectLandmark}
-            />
+          <MapMarkers
+            markers={this.props.markers || []}
+            setRegionAndSelectLandmark={this.setRegionAndSelectLandmark}
+          />
           {this.props.polyline.show && (
             <Polyline
               coordinates={this.props.polyline.coordinates}
@@ -161,11 +161,15 @@ class Map extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  polyline: state.directions
-})
+  polyline: state.directions,
+  markers: state.landmarks.data || []
+});
 
 const mapDispatchToProps = dispatch => ({
   selectLandmark: landmark => dispatch(setLandmark(landmark))
-})
+});
 
-export default connect(mapStateToProps, mapDispatchToProps)(Map)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Map);

--- a/screens/NearMe.js
+++ b/screens/NearMe.js
@@ -1,21 +1,27 @@
 import React from "react";
-import { View, ScrollView, Text } from "react-native";
+import { connect } from "react-redux";
+import { View, ScrollView, Text, TouchableOpacity } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
+import { setLandmark } from "../store/selectedLandmark";
 
-export default class NearMe extends React.Component {
+class NearMe extends React.Component {
   render() {
     const landmarks = this.props.landmarks;
     if (landmarks.length) {
       return (
         <ScrollView style={reusableStyles.block}>
           {landmarks.map(landmark => (
-            <View key={landmark.name} style={specificStyles.listItemWithIcon}>
+            <TouchableOpacity
+              key={landmark.name}
+              style={specificStyles.listItemWithIcon}
+              onPress={() => this.props.selectLandmark(landmark)}
+            >
               <View style={reusableStyles.listIcon} />
               <View>
                 <Text style={reusableStyles.header2}>{landmark.name}</Text>
                 <Text style={reusableStyles.text1}>{landmark.location}</Text>
               </View>
-            </View>
+            </TouchableOpacity>
           ))}
         </ScrollView>
       );
@@ -28,3 +34,17 @@ export default class NearMe extends React.Component {
     }
   }
 }
+
+const mapStateToProps = state => ({
+  landmarks: state.landmarks.data || [],
+  landmarkDetails: state.selectedLandmark || {}
+});
+
+const mapDispatchToProps = dispatch => ({
+  selectLandmark: landmark => dispatch(setLandmark(landmark))
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NearMe);

--- a/styles.js
+++ b/styles.js
@@ -44,7 +44,8 @@ export const reusableStyles = StyleSheet.create({
     flex: 1,
     margin: 5,
     padding: 2,
-    alignItems: "center"
+    alignItems: "center",
+    justifyContent: "center"
   }
 });
 


### PR DESCRIPTION
- refactored `Map`, `Drawer`, and `NearMe` components so they pull landmarks from the store in instead of passing them down as props
- added `onPress` handlers in `List` and `NearMe` to select the landmark when the user taps it
- small style change in `List` to render the delete button to the right of the landmark name, instead of below it