### PR TITLE
#79 - bug with select landmark

### DIFF
--- a/screens/ExploreBrooklyn.js
+++ b/screens/ExploreBrooklyn.js
@@ -30,7 +30,11 @@ class ExploreBrooklyn extends React.Component {
   };
 
   componentDidUpdate(prevProps) {
-    if (prevProps.landmarkDetails !== this.props.landmarkDetails) {
+    const propsChanged =
+      prevProps.landmarkDetails !== this.props.landmarkDetails;
+    const haveLandmark = !!this.props.landmarkDetails.name;
+
+    if (propsChanged && haveLandmark) {
       this.setState({
         showNearMe: false,
         showSavedList: false
@@ -41,7 +45,7 @@ class ExploreBrooklyn extends React.Component {
   render() {
     const { showNearMe, showSavedList } = this.state;
     const showLandmarkDetails =
-      this.props.landmarkDetails.name && !showNearMe && !showSavedList;
+      !!this.props.landmarkDetails.name && !showNearMe && !showSavedList;
 
     return (
       <View>

--- a/screens/Landmark.js
+++ b/screens/Landmark.js
@@ -9,8 +9,13 @@ import {
 } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
 import { getDirections, clearDirections } from "../store/directions";
+import { clearLandmark } from "../store/selectedLandmark";
 
 class LandmarkScreen extends React.Component {
+  componentWillUnmount = () => {
+    this.props.clearLandmark();
+  };
+
   async saveLandmark(landmarkToSave) {
     //grab the current saved landmarks from async storage
     try {
@@ -124,7 +129,8 @@ class LandmarkScreen extends React.Component {
 
 const mapDispatchToProps = dispatch => ({
   fetchDirections: coordinate => dispatch(getDirections(coordinate)),
-  clearDirections: () => dispatch(clearDirections())
+  clearDirections: () => dispatch(clearDirections()),
+  clearLandmark: () => dispatch(clearLandmark())
 });
 
 export default connect(

--- a/store/selectedLandmark.js
+++ b/store/selectedLandmark.js
@@ -2,9 +2,11 @@ import Constants from "expo-constants";
 
 //Action Constants
 const SET_LANDMARK = "SET_LANDMARK";
+const CLEAR_LANDMARK = "CLEAR_LANDMARK";
 
 //Action Creators
 export const setLandmark = landmark => ({ type: SET_LANDMARK, landmark });
+export const clearLandmark = () => ({ type: CLEAR_LANDMARK });
 
 //Thunks
 export const selectLandmark = data => async dispatch => {
@@ -44,6 +46,8 @@ const selectedLandmark = (state = initialState, action) => {
   switch (action.type) {
     case SET_LANDMARK:
       return action.landmark;
+    case CLEAR_LANDMARK:
+      return {};
     default:
       return state;
   }


### PR DESCRIPTION
- Added `clearLandmark` action to `selectedLandmark` reducer
- Added logic in `Landmark` screen to clear the landmark when the component unmounts
- Updated logic in `componentDidUpdate` method in `ExploreBrooklyn` screen to check if the props have changed and if we have a landmark in order to show the landmarks details screen
- Added `!!` in front of `this.props.landmarkDetails.name` to convert string into a boolean