### PR TITLE
#79 - bug with select landmark

### DIFF
--- a/screens/ExploreBrooklyn.js
+++ b/screens/ExploreBrooklyn.js
@@ -34,7 +34,11 @@ class ExploreBrooklyn extends React.Component {
   };
 
   componentDidUpdate(prevProps) {
-    if (prevProps.landmarkDetails !== this.props.landmarkDetails) {
+    const propsChanged =
+      prevProps.landmarkDetails !== this.props.landmarkDetails;
+    const haveLandmark = !!this.props.landmarkDetails.name;
+
+    if (propsChanged && haveLandmark) {
       this.setState({
         showNearMe: false,
         showSavedList: false

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -2,10 +2,10 @@ import React from "react";
 import { connect } from "react-redux";
 import { View, Text, TouchableOpacity } from "react-native";
 import Map from "./Map";
-import ExploreBrooklyn from "./ExploreBrooklyn"
+import ExploreBrooklyn from "./ExploreBrooklyn";
 import { specificStyles } from "../styles";
 import { database } from "../db.js";
-import { fetchLandmarks } from "../store/landmarks";
+import { getLandmarksAction } from "../store/landmarks";
 
 class HomeScreen extends React.Component {
   constructor(props) {
@@ -24,14 +24,14 @@ class HomeScreen extends React.Component {
   };
 
   render() {
-    return (
-    !this.props.err ?
-    <View style={specificStyles.main}>
-      <View>
-        <ExploreBrooklyn/>
-          <Map/>
+    return !this.props.err ? (
+      <View style={specificStyles.main}>
+        <View>
+          <ExploreBrooklyn />
+          <Map />
         </View>
-      </View> :
+      </View>
+    ) : (
       <View style={specificStyles.main}>
         <Text>There was a problem loading the landmarks.</Text>
         <TouchableOpacity onClick={() => this.props.getLandmarks(this.db)}>
@@ -48,7 +48,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  getLandmarks: db => dispatch(fetchLandmarks(db))
+  getLandmarks: db => dispatch(getLandmarksAction(db))
 });
 
 export default connect(

--- a/screens/Landmark.js
+++ b/screens/Landmark.js
@@ -8,19 +8,22 @@ import {
   ScrollView
 } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
-import { getDirections, clearDirections } from "../store/directions";
-import { clearLandmark } from "../store/selectedLandmark";
+import {
+  getDirectionsAction,
+  clearDirectionsAction
+} from "../store/directions";
+import { clearLandmarkAction } from "../store/selectedLandmark";
 
 class LandmarkScreen extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       seeMoreSelected: false
-    }
+    };
   }
   componentWillUnmount = () => {
     this.props.clearLandmark();
-  }
+  };
 
   async saveLandmark(landmarkToSave) {
     //grab the current saved landmarks from async storage
@@ -48,32 +51,33 @@ class LandmarkScreen extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState){
-    if (this.props.landmarkDetails.name !== prevProps.landmarkDetails.name){
-      this.setState({seeMoreSelected: false})
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.landmarkDetails.name !== prevProps.landmarkDetails.name) {
+      this.setState({ seeMoreSelected: false });
     }
   }
 
   getDirectionsToLandmark = landmarkCoordinates => {
-    this.props.fetchDirections(landmarkCoordinates);
+    this.props.getDirections(landmarkCoordinates);
     this.props.closeDrawer();
-  }
+  };
 
-  getDescription = (type) => {
-    const { landmarkDetails } = this.props
+  getDescription = type => {
+    const { landmarkDetails } = this.props;
     let description = landmarkDetails.description;
     let descriptionMaxWordLength = 500;
     let shortDescriptionMaxWordLength = 100;
 
-    if (type === 'teaser') {
-      description = description.slice(0, shortDescriptionMaxWordLength)
-    }
-
-    else if (description.length > descriptionMaxWordLength && !this.state.seeMoreSelected) {
+    if (type === "teaser") {
+      description = description.slice(0, shortDescriptionMaxWordLength);
+    } else if (
+      description.length > descriptionMaxWordLength &&
+      !this.state.seeMoreSelected
+    ) {
       description = description.slice(0, descriptionMaxWordLength) + "...";
     }
-    return description
-  }
+    return description;
+  };
 
   render() {
     const { landmarkDetails } = this.props;
@@ -96,13 +100,13 @@ class LandmarkScreen extends React.Component {
         <View style={reusableStyles.block}>
           <View style={reusableStyles.flexrow}>
             <View style={specificStyles.insetPic} />
-            <TouchableOpacity onPress={() => this.props.eraseDirections()}>
+            <TouchableOpacity onPress={() => this.props.clearDirections()}>
               <Text style={reusableStyles.header1}> X </Text>
             </TouchableOpacity>
           </View>
           <Text style={reusableStyles.header1}>{name}</Text>
           <Text style={reusableStyles.text1}>
-            {this.getDescription('teaser')}
+            {this.getDescription("teaser")}
           </Text>
           <View style={reusableStyles.flexrow}>
             <TouchableOpacity
@@ -124,13 +128,19 @@ class LandmarkScreen extends React.Component {
         <ScrollView style={reusableStyles.block}>
           <Text style={reusableStyles.header2}>Her Story</Text>
           <Text style={reusableStyles.text1}>{this.getDescription()}</Text>
-          {this.state.seeMoreSelected ?
-          <TouchableOpacity onPress={() => this.setState({seeMoreSelected: false})}>
-            <Text style={reusableStyles.header2}>See Less</Text>
-          </TouchableOpacity> :
-          <TouchableOpacity onPress={() => this.setState({seeMoreSelected: true})}>
-            <Text style={reusableStyles.header2}>See More</Text>
-          </TouchableOpacity>}
+          {this.state.seeMoreSelected ? (
+            <TouchableOpacity
+              onPress={() => this.setState({ seeMoreSelected: false })}
+            >
+              <Text style={reusableStyles.header2}>See Less</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              onPress={() => this.setState({ seeMoreSelected: true })}
+            >
+              <Text style={reusableStyles.header2}>See More</Text>
+            </TouchableOpacity>
+          )}
         </ScrollView>
         <View style={reusableStyles.block}>
           <Text style={reusableStyles.header2}>Contact Details</Text>
@@ -161,9 +171,12 @@ class LandmarkScreen extends React.Component {
 }
 
 const mapDispatchToProps = dispatch => ({
-  fetchDirections: coordinate => dispatch(getDirections(coordinate)),
-  eraseDirections: () => dispatch(clearDirections()),
-  clearLandmark: () => dispatch(clearLandmark())
+  getDirections: coordinate => dispatch(getDirectionsAction(coordinate)),
+  clearDirections: () => dispatch(clearDirectionsAction()),
+  clearLandmark: () => dispatch(clearLandmarkAction())
 });
 
-export default connect(null, mapDispatchToProps)(LandmarkScreen);
+export default connect(
+  null,
+  mapDispatchToProps
+)(LandmarkScreen);

--- a/screens/Landmark.js
+++ b/screens/Landmark.js
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
 import { getDirections, clearDirections } from "../store/directions";
+import { clearLandmark } from "../store/selectedLandmark";
 
 class LandmarkScreen extends React.Component {
   constructor(props) {
@@ -17,6 +18,10 @@ class LandmarkScreen extends React.Component {
       seeMoreSelected: false
     }
   }
+  componentWillUnmount = () => {
+    this.props.clearLandmark();
+  }
+
   async saveLandmark(landmarkToSave) {
     //grab the current saved landmarks from async storage
     try {
@@ -52,7 +57,7 @@ class LandmarkScreen extends React.Component {
   getDirectionsToLandmark = landmarkCoordinates => {
     this.props.fetchDirections(landmarkCoordinates);
     this.props.closeDrawer();
-  };
+  }
 
   getDescription = (type) => {
     const { landmarkDetails } = this.props
@@ -157,7 +162,8 @@ class LandmarkScreen extends React.Component {
 
 const mapDispatchToProps = dispatch => ({
   fetchDirections: coordinate => dispatch(getDirections(coordinate)),
-  eraseDirections: () => dispatch(clearDirections())
+  eraseDirections: () => dispatch(clearDirections()),
+  clearLandmark: () => dispatch(clearLandmark())
 });
 
 export default connect(null, mapDispatchToProps)(LandmarkScreen);

--- a/screens/List.js
+++ b/screens/List.js
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { View, Text, AsyncStorage, TouchableOpacity } from "react-native";
 import { reusableStyles, specificStyles } from "../styles";
-import { setLandmark } from "../store/selectedLandmark";
+import { selectLandmarkAction } from "../store/selectedLandmark";
 
 class List extends React.Component {
   constructor() {
@@ -100,7 +100,7 @@ class List extends React.Component {
 const mapStateToProps = () => ({});
 
 const mapDispatchToProps = dispatch => ({
-  selectLandmark: landmark => dispatch(setLandmark(landmark))
+  selectLandmark: landmark => dispatch(selectLandmarkAction(landmark))
 });
 
 export default connect(

--- a/screens/Map.js
+++ b/screens/Map.js
@@ -12,7 +12,7 @@ import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import MenuBtn from "./MenuBtn";
 import { specificStyles } from "../styles";
-import { setLandmark } from "../store/selectedLandmark";
+import { selectLandmarkAction } from "../store/selectedLandmark";
 
 const MapMarkers = ({ markers, setRegionAndSelectLandmark }) => {
   if (markers)
@@ -166,7 +166,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  selectLandmark: landmark => dispatch(setLandmark(landmark))
+  selectLandmark: landmark => dispatch(selectLandmarkAction(landmark))
 });
 
 export default connect(

--- a/screens/NearMe.js
+++ b/screens/NearMe.js
@@ -1,9 +1,8 @@
 import React from "react";
 import { ScrollView, View, Text, TouchableOpacity } from "react-native";
-import {connect} from 'react-redux'
+import { connect } from "react-redux";
 import { reusableStyles, specificStyles } from "../styles";
-import { setLandmark } from "../store/selectedLandmark";
-
+import { selectLandmarkAction } from "../store/selectedLandmark";
 
 class NearMe extends React.Component {
   render() {
@@ -46,7 +45,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  selectLandmark: landmark => dispatch(setLandmark(landmark))
+  selectLandmark: landmark => dispatch(selectLandmarkAction(landmark))
 });
 
 export default connect(

--- a/store/directions.js
+++ b/store/directions.js
@@ -8,10 +8,10 @@ const CLEAR_DIRECTIONS = "CLEAR_DIRECTIONS";
 
 //Action creators
 const setDirections = directions => ({ type: SET_DIRECTIONS, directions });
-export const clearDirections = () => ({ type: CLEAR_DIRECTIONS });
+export const clearDirectionsAction = () => ({ type: CLEAR_DIRECTIONS });
 
 //Thunks
-export const getDirections = landmarkCoordinates => async dispatch => {
+export const getDirectionsAction = landmarkCoordinates => async dispatch => {
   const location = await Location.getCurrentPositionAsync({});
   const {
     coords: { latitude: initialLat, longitude: initialLong }

--- a/store/landmarks.js
+++ b/store/landmarks.js
@@ -7,7 +7,7 @@ const gotLandmarks = landmarks => ({ type: GOT_LANDMARKS, landmarks });
 const threwError = err => ({ type: ERROR_GETTING_LANDMARKS, err });
 
 //Thunks
-export const fetchLandmarks = db => async dispatch => {
+export const getLandmarksAction = db => async dispatch => {
   try {
     db.once("value", snap => {
       const data = [];

--- a/store/selectedLandmark.js
+++ b/store/selectedLandmark.js
@@ -2,9 +2,11 @@ import Constants from "expo-constants";
 
 //Action Constants
 const SET_LANDMARK = "SET_LANDMARK";
+const CLEAR_LANDMARK = "CLEAR_LANDMARK";
 
 //Action Creators
 export const setLandmark = landmark => ({ type: SET_LANDMARK, landmark });
+export const clearLandmark = () => ({ type: CLEAR_LANDMARK });
 
 //Thunks
 export const selectLandmark = data => async dispatch => {
@@ -44,6 +46,8 @@ const selectedLandmark = (state = initialState, action) => {
   switch (action.type) {
     case SET_LANDMARK:
       return action.landmark;
+    case CLEAR_LANDMARK:
+      return {};
     default:
       return state;
   }

--- a/store/selectedLandmark.js
+++ b/store/selectedLandmark.js
@@ -5,11 +5,11 @@ const SET_LANDMARK = "SET_LANDMARK";
 const CLEAR_LANDMARK = "CLEAR_LANDMARK";
 
 //Action Creators
-export const setLandmark = landmark => ({ type: SET_LANDMARK, landmark });
-export const clearLandmark = () => ({ type: CLEAR_LANDMARK });
+const setLandmark = landmark => ({ type: SET_LANDMARK, landmark });
+export const clearLandmarkAction = () => ({ type: CLEAR_LANDMARK });
 
 //Thunks
-export const selectLandmark = data => async dispatch => {
+export const selectLandmarkAction = data => async dispatch => {
   let placeId = data.placeId;
   let selectedLandmark = { ...data };
 


### PR DESCRIPTION
-  Added `clearLandmark` action to `selectedLandmark` reducer
- Added logic in `Landmark` screen to clear the landmark when the component unmounts
- Updated logic in `componentDidUpdate` method in `ExploreBrooklyn` screen to check if the props have changed and if we have a landmark in order to show the landmarks details screen
- Added !! in front of `this.props.landmarkDetails.name` to convert string into a boolean